### PR TITLE
arm: don't unroll-loops

### DIFF
--- a/core/combo/TARGET_linux-arm.mk
+++ b/core/combo/TARGET_linux-arm.mk
@@ -124,7 +124,6 @@ $(combo_2nd_arch_prefix)TARGET_GLOBAL_CFLAGS += \
 			-w \
 			-O3 \
 			-fno-inline-functions \
-			-funroll-loops \
 			-mvectorize-with-neon-quad
 
 # This is to avoid the dreaded warning compiler message:


### PR DESCRIPTION
-O3 uses tree vectorizing, and unrolling loop is not recommended.

Thanks to @Khaon for tipping me this.

Signed-off-by: Park Ju Hyung <qkrwngud825@gmail.com>