### PR TITLE
img_from_target_files: Skip oem.img in fastboot image creation

### DIFF
--- a/tools/releasetools/img_from_target_files.py
+++ b/tools/releasetools/img_from_target_files.py
@@ -112,11 +112,13 @@ def main(argv):
     if os.path.exists(images_path):
       # If this is a new target-files, it already contains the images,
       # and all we have to do is copy them to the output zip.
+      # Skip oem.img files since they are not needed in fastboot images.
       images = os.listdir(images_path)
       if images:
         for i in images:
           if bootable_only and i not in ("boot.img", "recovery.img"): continue
           if not i.endswith(".img"): continue
+          if i == "oem.img": continue
           with open(os.path.join(images_path, i), "r") as f:
             common.ZipWriteStr(output_zip, i, f.read())
         done = True
@@ -164,12 +166,6 @@ def main(argv):
         add_img_to_target_files.AddUserdataExtra(output_zip, prefix="")
         banner("AddCache")
         add_img_to_target_files.AddCache(output_zip, prefix="")
-        try:
-          input_zip.getinfo("OEM/")
-          banner("AddOem")
-          add_img_to_target_files.AddOem(output_zip, prefix="")
-        except KeyError:
-          pass   # no oem partition for this device
 
   finally:
     print "cleaning up..."


### PR DESCRIPTION
We don't need this package to be included in fastboot images, so skip
it when we are creating fastboot images.

Change-Id: I1e0676f5cbf7468088e6997f83ae845578864668
Ticket: CYNGNOS-936